### PR TITLE
Added fingerprinter for the Adobe AEM content management system. 

### DIFF
--- a/lib/db/adminpanel.wascan
+++ b/lib/db/adminpanel.wascan
@@ -60,3 +60,9 @@ admin.thtml
 admin.rhtml
 xgadmin.asp
 pnadmin.php
+/crx/de/index.jsp
+/crx/explorer/index.jsp
+/crx/packmgr/service.jsp
+/libs/granite/security.3.json
+/system/console
+/libs/granite/backup/content/admin.html

--- a/plugins/fingerprint/cms/adobeaem.py
+++ b/plugins/fingerprint/cms/adobeaem.py
@@ -13,4 +13,5 @@ def adobeaem(headers,content):
 	_ |= search(r"<link[^>]*stylesheet[^>]*etc\/designs\/[^>]*\>[^<]*",content) is not None
 	_ |= search(r"<link[^>]*etc\/clientlibs\/[^>]*\>[^<]*",content) is not None
 	_ |= search(r"<script[^>]*etc\/clientlibs\/[^>]*\>[^<]*",content) is not None
-	if _ : return "Adobe AEM"
+	_ |= search(r"<script[^>]*\/granite\/[^>]*(\.js\")+\>[^<]*",content) is not None
+	if _ : return "Adobe AEM: Stack is based on Apache Sling + Apache Felix OSGi container + JCR Repo + Java"

--- a/plugins/fingerprint/cms/adobeaem.py
+++ b/plugins/fingerprint/cms/adobeaem.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python 
+# -*- coding:utf-8 -*-
+#
+# @name:    Wascan - Web Application Scanner
+# @repo:    https://github.com/m4ll0k/Wascan
+# @author:  Thomas Hartmann (thomysec)
+# @license: See the file 'LICENSE.txt'
+
+from re import search,I 
+
+def adobeaem(headers,content):
+	_  = False
+	_ |= search(r"<link[^>]*stylesheet[^>]*etc\/designs\/[^>]*\>[^<]*",content) is not None
+	_ |= search(r"<link[^>]*etc\/clientlibs\/[^>]*\>[^<]*",content) is not None
+	_ |= search(r"<script[^>]*etc\/clientlibs\/[^>]*\>[^<]*",content) is not None
+	if _ : return "Adobe AEM"

--- a/plugins/fingerprint/framework/apachejackrabbit.py
+++ b/plugins/fingerprint/framework/apachejackrabbit.py
@@ -8,7 +8,7 @@
 
 from re import search,I
 
-def apachesling(headers,content):
+def apachejackrabbit(headers,content):
 	_ = False
 	_ |= search(r"<\w[^>]*(=\"\/_jcr_content\/){1}[^>]*\>",content) is not None	
-	if _ : return "Apache Sling + Apache Felix OSGi container + Apache Jackrabbit/Adobe CRX repository + Java"
+	if _ : return "Apache Jackrabbit/Adobe CRX repository"

--- a/plugins/fingerprint/framework/apachesling.py
+++ b/plugins/fingerprint/framework/apachesling.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python 
+# -*- coding:utf-8 -*-
+#
+# @name:    Wascan - Web Application Scanner
+# @repo:    https://github.com/m4ll0k/Wascan
+# @author:  Thomas Hartmann (thomysec)
+# @license: See the file 'LICENSE.txt
+
+from re import search,I
+
+def apachesling(headers,content):
+	_ = False
+	_ |= search(r"<\w[^>]*(=\"\/_jcr_content\/){1}[^>]*\>",content) is not None	
+	if _ : return "Apache Sling + Apache Felix OSGi container + Apache Jackrabbit/Adobe CRX repository + Java"


### PR DESCRIPTION
AEM installations can be usually identified by the etc/designs and /etc/clientlibs paths for css and icons.